### PR TITLE
webapi: fix packaging

### DIFF
--- a/webapi/MANIFEST.in
+++ b/webapi/MANIFEST.in
@@ -1,0 +1,3 @@
+graft src/pacbed_api/templates/
+graft src/pacbed_api/static/
+include README.md

--- a/webapi/setup.cfg
+++ b/webapi/setup.cfg
@@ -2,7 +2,7 @@
 name = pacbed_api
 version = 0.0.1
 author = Alexander Clausen
-author-email = a.clausen@fz-juelich.de
+author_email = a.clausen@fz-juelich.de
 
 [options]
 zip_safe = False
@@ -18,3 +18,6 @@ install_requires =
     tensorflow-cpu
     pandas
     ncempy @ git+https://github.com/ercius/openNCEM.git@4b1132bc675debda95e02fec4aa40ce4e010e6fa
+
+[options.packages.find]
+where = src


### PR DESCRIPTION
Include templates and static files in wheel; fix package discovery (needs the `where` option to find)